### PR TITLE
Use static name instead of dynamic class name

### DIFF
--- a/google-meet.js
+++ b/google-meet.js
@@ -36,7 +36,7 @@ class GoogleMeet {
 
             await this.page.waitFor(7000)
 
-            await this.page.type("input.whsOnd.zHQkBf", this.pass, {
+            await this.page.type("input[name=password]", this.pass, {
                 delay: 0
             })
             await this.page.click("div#passwordNext")


### PR DESCRIPTION
The class name can change on each deployment of the Gmail. So it's better to use the input name instead of the class name.